### PR TITLE
PIPE-5862 - update icon name to fail new regex

### DIFF
--- a/resources/test/TestResource/resourceModel.yml
+++ b/resources/test/TestResource/resourceModel.yml
@@ -1,4 +1,4 @@
-icon: el-scissors
+icon: el-scissors-123
 platforms:
   - os: Linux
 configuration:


### PR DESCRIPTION
new icon name so that this test continues to fail once the regex validation is updated